### PR TITLE
feat: enhance stack management with env vars and stack removal option

### DIFF
--- a/cmd/pedloy/destroy/cli.go
+++ b/cmd/pedloy/destroy/cli.go
@@ -45,6 +45,7 @@ func Command() *cobra.Command {
 			org := v.GetString("org")
 			jsonLogger := v.GetBool("json")
 			preview := v.GetBool("preview")
+			rm := v.GetBool("rm")
 
 			// Perform preview or destruction
 			if preview {
@@ -53,7 +54,7 @@ func Command() *cobra.Command {
 					return fmt.Errorf("preview failed: %w", err)
 				}
 			} else {
-				auto.Destroy(org, projects, source, jsonLogger)
+				auto.Destroy(org, projects, source, jsonLogger, rm)
 			}
 
 			return nil
@@ -68,6 +69,7 @@ func Command() *cobra.Command {
 	cmd.Flags().String("git-branch", "main", "The Git branch to use")
 	cmd.Flags().Bool("preview", false, "Preview the destruction plan")
 	cmd.Flags().Bool("json", false, "Enable JSON logging")
+	cmd.Flags().Bool("rm", false, "Delete the stack after destruction")
 
 	return cmd
 }


### PR DESCRIPTION
- **allow setting aws-profile per stack**
- **use fang and ver for libraries**
- **output failed resources**
- **allow any env vars on stacks**
- **add an option to remove stacks on destroy**

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhance stack management by allowing environment variables per stack, adding stack removal option, and outputting failed resources.
> 
>   - **Environment Variables**:
>     - Allow setting environment variables per stack in `pkg/project/projects.go`.
>     - Update `deployStack()` and `Destroy()` in `pkg/auto/pulumi.go` to set/unset env vars.
>   - **Stack Removal**:
>     - Add `--rm` flag in `cmd/pedloy/destroy/cli.go` to remove stacks after destruction.
>     - Update `Destroy()` in `pkg/auto/pulumi.go` to handle stack removal.
>   - **Error Handling**:
>     - Output failed resources in `Destroy()` in `pkg/auto/pulumi.go`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=jaxxstorm%2Fpedloy&utm_source=github&utm_medium=referral)<sup> for f0d707911f3edac66ba3072af284aa74473e5a6f. You can [customize](https://app.ellipsis.dev/jaxxstorm/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->